### PR TITLE
Fix typo in README for translated_inputs

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -122,7 +122,7 @@ app/admin/page.rb:
         t.input :title
         t.input :content
         # ...
-        f.seo_meta_inputs
+        t.seo_meta_inputs
       end
       # ...
     end


### PR DESCRIPTION
The form variable for which `seo_meta_inputs` should be called is (in this case) `t`, from the `translated_inputs` block.
