### PR TITLE
Fix for models not seoable with FriendlyId

### DIFF
--- a/lib/friendly_id/translated_seo_meta.rb
+++ b/lib/friendly_id/translated_seo_meta.rb
@@ -85,8 +85,10 @@ module FriendlyId
     def first_by_friendly_id(id)
       if self.first.try(:seo_meta)
         ActiveAdmin::Seo::Meta.where(slug: id, seoable_type: self.first.class.name).first.try(:seoable) if self.first
-      else
+      elsif self.first.try(:translation)
         ActiveAdmin::Seo::Meta.where(slug: id, seoable_type: self.first.translation.class.name).first.try(:seoable).try(:globalized_model) if self.first
+      else
+        self.first.class.name.constantize.where(slug: id).first if self.first
       end
     end
 


### PR DESCRIPTION
When a model had FriendlyId but it was not seoable we were looking at the translation, but it's wrong. Now should be fixed.
